### PR TITLE
update-type, remove-type, change recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+
+0.5.4
+
+ - Added the possibility to run "add-type" several times, which overwrites existing types
+ - Added a command argument "remove-type" to remove a type
+ - Added a command option "force-update" to ignore code change warnings and overwrites changed files
+ - Fix issue with "Allow running add-type twice" 
+   https://github.com/tmeasday/create-graphql-server/issues/12
+ - Fix issue with "Added update-type and remove-type"
+   https://github.com/tmeasday/create-graphql-server/issues/29
+
 0.5.3
 
  - Fix issue with needing babel-cli: https://github.com/tmeasday/create-graphql-server/issues/27

--- a/README.md
+++ b/README.md
@@ -2,26 +2,28 @@
 
 This is a simple scaffolding tool for GraphQL apps, built on MongoDB.
 
-It consists of two commands:
+It consists of different commands:
 
 ```bash
-create-graphql-server init project-dir
+create-graphql-server init project-dir 
 ```
 
 Create the basic skeleton of a GraphQL server project. If you `yarn install` inside `project-dir`, you should be able to `npm start` it, and then browse to http://localhost:3010/graphiql to start running queries.
 
 There isn't anything to query yet however!
 
-To add some types, simply run:
+To add some types, simply run one of the following alternatives:
 
 ```bash
 create-graphql-server add-type path/to/input.graphql
+OR:
+create-grapqhl-server add-type path
 ```
 
-Where `path/to/input.graphql` is an input GraphQL schema (see below).
+Where `path/to/input.graphql` is an input GraphQL schema (see below). Or:
+Where `path` will add all `type.graphql` files in the given directory path recursively.
 
 To see what a complete generated server looks like, see the `test/output-app` folder. It has been generated from the `test/input` schema inputs.
-
 
 ## Creating types
 
@@ -69,6 +71,34 @@ If the field references an array (again w/ or w/o nullability) of another type, 
 - `@belongsToMany` - there is a list of foreign keys stored on this type as `${fieldName}Ids` [this is the default]
 - `@hasMany` - the foreign key is on the referenced type as `${typeName}Id`. Provide the `"as": X` argument if the name is different. (this is the reverse of `@belongsTo` in a 1-many situation).
 - `@hasAndBelongsToMany` - the foreign key on the referenced type as `${typeName}Ids`. Provide the `"as": X` argument if the name is different. (this is the reverse of `@belongsToMany` in a many-many situation).
+
+## Updating types
+
+To update types, just re-run add-type again:
+
+```bash
+create-graphql-server add-type path/to/input.graphql [--force-update]
+```
+
+This overwrites your old *type* specific files from the directories: schema, model, resolvers.
+
+It recognizes, if you've changed any code file, which will be overwritten by the generator and stops and warns. If you are sure, you want to overwrite your changes, then just use the *--force-update* option.
+
+## Removing types
+
+To remove types, use the following command with the path to the GraphQL file, or as alternative, just enter the type name without path.
+
+```bash
+create-graphql-server remove-type path/to/input.graphql
+
+create-graphql-server remove-type typename
+
+create-graphql-server remove-type path
+```
+
+This command deletes your old *type* specific files from the directories: schema, model, resolvers. It also removes the code references out of the corresponding index files.
+
+It recognizes, if you've changed any code file, which will be overwritten by the generator and stops and warns. If you are sure, you want to overwrite your changes, then just use the *force-update* option.
 
 ## Authentication
 

--- a/bin/create-graphql-server.js
+++ b/bin/create-graphql-server.js
@@ -8,29 +8,440 @@ import cpr from 'cpr';
 import minimist from 'minimist';
 import generate from '../generate';
 import child_process from 'child_process';
+import escapeStringRegexp from 'escape-string-regexp';
+import md5 from 'md5';
+import chalk from 'chalk';
 
-const argv = minimist(process.argv.slice(2));
-
+const argv = minimist(process.argv.slice(2), {
+  default: {
+    'force-update': false,
+  },
+});
 const commands = argv._;
-
 const SKEL_DIR = path.join(__dirname, '..', 'skel');
+const CHECKSUM_FILE = path.join(
+  process.cwd(),
+  '.create-graphql-server.checksums'
+);
 
 function usage() {
-  console.log('Usage: create-graphql-app <command> <arg>, where command is:');
-  console.log(' - create-graphql-app init project-dir');
-  console.log(' - create-graphql-app add-type path/to/type.graphql');
+  console.log(
+    'Generate a GraphQL Server environment, or add/update/remove GraphQL data types and generate code files and schemas.'
+  );
+  console.log('');
+  console.log(
+    'Usage:',
+    chalk.bold.yellow(
+      'create-graphql-server <command> <argument> <option>, where command is:'
+    )
+  );
+  console.log('');
+  console.log(' - create-graphql-server init project-dir');
+  console.log(' - create-graphql-server add-type path/to/type.graphql');
+  console.log(' - create-graphql-server add-type path');
+  console.log(' - create-graphql-server remove-type path/to/type.graphql');
+  console.log(' - create-graphql-server remove-type path');
+  console.log(' - create-graphql-server remove-type typename');
+  console.log('');
+  console.log(chalk.yellow(' Commands:'));
+  console.log('');
+  console.log(
+    ' init           initializes and generates a new graphql-server project environment'
+  );
+  console.log(
+    ' add-type       adds your new Graphql data type to the graphql-server'
+  );
+  console.log(
+    ' remove-type    removes a Graphql data type from the graphql-server (does not delete data in db)'
+  );
+  console.log('');
+  console.log(chalk.yellow(' Argument:'));
+  console.log('');
+  console.log(
+    ' file-path      path of your <type>.graphql file e.g.: ./input/User.graphql'
+  );
+  console.log('');
+  console.log(chalk.yellow(' Options:'));
+  console.log('');
+  console.log(
+    ' --force-update forces updates, overwriting code changes by any user since last run'
+  );
+  console.log('');
   process.exit(1);
 }
+
+function adjustTypeName(typeName){
+  return typeName.charAt(0).toUpperCase() + typeName.slice(1).toLowerCase();
+}
+
+function getFileUpdateList(inputSchemaFile, mode) {
+  let inputSchemaStr = '';
+  // in add mode or if a graphql path/file name was provided, the input file must be there,
+  if (mode === 'add' || inputSchemaFile.includes('.graphql') || inputSchemaFile.includes('/')) {
+    if (! fs.existsSync(inputSchemaFile)) {
+      console.error(
+        chalk.bold.red('Error: Cannot read file', inputSchemaFile)
+      );
+      console.log('');
+      process.exit(1);
+    }
+    // get information about the entity <type> out of its input file
+    inputSchemaStr = fs.readFileSync(inputSchemaFile, 'utf8');
+  } else {
+    // expecting just the type name without path/file name
+    // provide a dummy type file just with the type name
+    inputSchemaStr = `type ${adjustTypeName(inputSchemaFile)} {}`;
+  }
+
+  // generate code therefore in memory first
+  const {
+    typeName,
+    TypeName,
+    outputSchemaStr,
+    resolversStr,
+    modelStr,
+  } = generate(inputSchemaStr);
+
+  // do validation checks
+  // shouldn't be necessary, but...
+  if (typeName === '' || TypeName === '') {
+    console.error('Error: No valid <Type> found.');
+    process.exit(0);
+  }
+  // there should be some generated code, not adding missing or empty code files
+  if (
+    !outputSchemaStr ||
+    !resolversStr ||
+    !modelStr ||
+    outputSchemaStr === '' ||
+    resolversStr === '' ||
+    modelStr === ''
+  ) {
+    console.error('Error: Error while generating target Code.');
+    process.exit(0);
+  }
+
+  // Bill-of-material for the changes to be applied
+  // Add further enhancements to this array
+  //
+  // @Records:
+  // One record represents one file <type> with its path, code and reference
+  //
+  // @Fields:
+  // typePath: path and file name for the <type> file
+  // typeString: generated code for the <type> file
+  // indexPath: path and file name for the index file, which has to reference the <type> file
+  // indexPattern: code pattern to be added to the index file, for referencing this <type> file
+  return [
+    {
+      typePath: path.join('schema', `${TypeName}.graphql`),
+      typeString: outputSchemaStr,
+      indexPath: path.join('schema', 'index.js'),
+      indexPattern: `\ntypeDefs.push(requireGraphQL('./${TypeName}.graphql'));\n`,
+    },
+    {
+      typePath: path.join('resolvers', `${TypeName}.js`),
+      typeString: resolversStr,
+      indexPath: path.join('resolvers', 'index.js'),
+      indexPattern: `\nimport ${typeName}Resolvers from './${TypeName}';\n` +
+        `merge(resolvers, ${typeName}Resolvers);\n`,
+    },
+    {
+      typePath: path.join('model', `${TypeName}.js`),
+      typeString: modelStr,
+      indexPath: path.join('model', 'index.js'),
+      indexPattern: `\nimport ${TypeName} from './${TypeName}';\n` +
+        `models.${TypeName} = ${TypeName};\n`,
+    },
+  ];
+}
+
+function getEscapeRegex(pattern) {
+  // Prepare Regular Expression to find and replace code patterns
+  // Special characters in the code string have to be escaped, to get the regex working properly
+  // First with common escape patterns by the included npm module,
+  // Additionally escape ./ and \n, which weren't escaped by the npm module unfortunately
+  const re = new RegExp(
+    escapeStringRegexp(pattern) // use common escape patterns
+      .replace(/\.\//g, '.\\/') // escape: ./  to   \.\/ (which was in path)
+      .replace(/\n/g, '\\n'), // escape: \n  to:  \\n
+    'gmi'
+  );
+  return re;
+}
+
+function getFileHash(fileContent) {
+  return md5(fileContent);
+}
+
+function readFileHashFile() {
+  // read file with all file hashes from last add-type/update-type/remove-type runs
+  let checksums = {};
+  if (fs.existsSync(CHECKSUM_FILE)) {
+    checksums = JSON.parse(fs.readFileSync(CHECKSUM_FILE, 'utf8'));
+  }
+  return checksums;
+}
+
+function removeFileHash(file) {
+  // MD5_file_Hash_JSON = [ { 'User.graphql': 'md5abscdsadfasf234322'} ]
+  let checksums = [];
+  // Existing Hash File: Read and update file, remove the entry with <file>
+  if (file && file !== '' && fs.existsSync(CHECKSUM_FILE)) {
+    checksums = JSON.parse(fs.readFileSync(CHECKSUM_FILE, 'utf8'));
+    delete checksums[file];
+    fs.writeFileSync(CHECKSUM_FILE, JSON.stringify(checksums));
+  }
+}
+
+function writeFileHashFile(file, content) {
+  // MD5_file_Hash_JSON = { 'User.graphql': 'md5abscdsadfasf234322'}
+  let checksums = {};
+  // Existing Hash File: Read and update file
+  if (
+    file &&
+    file !== '' &&
+    content &&
+    content !== '' &&
+    fs.existsSync(CHECKSUM_FILE)
+  ) {
+    checksums = JSON.parse(fs.readFileSync(CHECKSUM_FILE, 'utf8'));
+    checksums[file] = getFileHash(content);
+    fs.writeFileSync(CHECKSUM_FILE, JSON.stringify(checksums));
+    // Not yet existing Hash File: create file
+  } else if (file && file !== '' && content && content !== '') {
+    checksums[file] = getFileHash(content);
+    fs.writeFileSync(CHECKSUM_FILE, JSON.stringify(checksums));
+  }
+}
+
+function hasFileChanged(file, checksums) {
+  // file has changed => true,
+  // file not changed => false
+  // file not found   => false
+  // If file is provided and existing,
+  // and also an old entry in the file is existing,
+  // then compare old and new hash
+  if (file && file !== '' && checksums[file] && fs.existsSync(file)) {
+    const oldFileHash = checksums[file];
+    const newFileHash = getFileHash(fs.readFileSync(file, 'utf8'));
+    if (oldFileHash !== newFileHash) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function checkForFileChanges(fileUpdateList, forceUpdate) {
+  // Get all old file hashes first
+  const checksums = readFileHashFile();
+  let anyFileHasChanged = false;
+  let thisFileHasChanged = false;
+  if (checksums) {
+    fileUpdateList.map((file) => {
+      // Check if <type> file has changed
+      thisFileHasChanged = hasFileChanged(file.typePath, checksums);
+      if (thisFileHasChanged) {
+        console.log(
+          chalk.bold.red('Caution: File has changed:', file.typePath)
+        );
+        anyFileHasChanged = anyFileHasChanged || thisFileHasChanged;
+      }
+      // Check if index file has changed
+      thisFileHasChanged = hasFileChanged(file.indexPath, checksums);
+      if (thisFileHasChanged) {
+        console.log(
+          chalk.bold.red('Caution: File has changed:', file.indexPath)
+        );
+        anyFileHasChanged = anyFileHasChanged || thisFileHasChanged;
+      }
+      return file;
+    });
+    // if any file has changed, stop
+    if (anyFileHasChanged && !forceUpdate) {
+      console.error(
+        chalk.bold.red('Stopping without change for safety reasons.')
+      );
+      console.error(
+        chalk.green('Please check you are not overwriting your changes.')
+      );
+      console.error(
+        chalk.green(
+          'You can still overwrite by using the --force-update option.'
+        )
+      );
+      console.error(' ');
+      process.exit(0);
+      // if any file has changed, but user chose force-update, then continue with changing files...
+    } else if (anyFileHasChanged && forceUpdate) {
+      console.log(
+        chalk.bold.yellow(
+          'Overwriting files --force-update option was chosen...'
+        )
+      );
+    }
+  }
+}
+
+function checkFileContainsPattern(file, pattern) {
+  // only checks, if the file contains a search pattern
+  if (pattern && file && fs.existsSync(file)) {
+    const inputFile = fs.readFileSync(file, 'utf8');
+    const re = getEscapeRegex(pattern);
+    const found = inputFile.match(re);
+    if (found === null) {
+      return false; // pattern not found
+    }
+    return true; // pattern found
+  }
+  console.error(
+    'Error: checkFileContainsPattern() requires an existing file:',
+    file,
+    ' and a pattern:',
+    pattern
+  );
+  process.exit(0);
+  return false;
+}
+
+function removePatternFromFile(file, pattern) {
+  // Remove <type> related code patterns from file
+  // which were added earlier by "add-type" to e.g. index.js file
+  if (file && pattern && fs.existsSync(file)) {
+    const inputFile = fs.readFileSync(file, 'utf8');
+    const re = getEscapeRegex(pattern);
+    const targetFile = inputFile.replace(re, '');
+    fs.writeFileSync(file, targetFile);
+    writeFileHashFile(file, targetFile);
+    console.log(chalk.green('File updated:', file));
+  }
+}
+
+function removePatternFromFiles(fileUpdateList) {
+  fileUpdateList.map((file) => {
+    removePatternFromFile(file.indexPath, file.indexPattern);
+    return file;
+  });
+}
+
+function removeFile(file) {
+  // deletes the file on existence
+  if (file && file !== '' && fs.existsSync(file)) {
+    fs.unlinkSync(file);
+    removeFileHash(file);
+    console.log(chalk.green('File removed:', file));
+  }
+}
+
+function removeTypeFiles(fileUpdateList) {
+  fileUpdateList.map((file) => {
+    removeFile(file.typePath);
+    return file;
+  });
+}
+
+function createTypeFile(file, content) {
+  // creates the <type> file with its generated code
+  if (file && content && file !== '') {
+    fs.writeFileSync(file, content);
+    writeFileHashFile(file, content);
+    console.log(chalk.green('File generated:', file));
+  }
+}
+
+function createTypeFiles(fileUpdateList) {
+  fileUpdateList.map((file) => {
+    createTypeFile(file.typePath, file.typeString);
+    return file;
+  });
+}
+
+function addPatternToFile(file, pattern) {
+  // appends the code pattern to the index file, for referencing the <type> file
+  if (checkFileContainsPattern(file, pattern)) {
+    // file contains pattern already, do nothing
+    console.log(
+      chalk.green('Skipping file:', file, 'code pattern already in file.')
+    );
+  } else if (fs.existsSync(file)) {
+    fs.appendFileSync(file, pattern);
+    const content = fs.readFileSync(file, 'utf8');
+    writeFileHashFile(file, content);
+    console.log(
+      chalk.green('File enhanced: ', file, 'with required reference.')
+    );
+  } else {
+    console.error(
+      chalk.bold.red(
+        'ERROR: File to be enhanced: ',
+        file,
+        'with required reference, does not exist.'
+      )
+    );
+  }
+}
+
+function addPatternToFiles(fileUpdateList) {
+  fileUpdateList.map((file) => {
+    addPatternToFile(file.indexPath, file.indexPattern);
+    return file;
+  });
+}
+
+function getFilesRecursively(folder, filetype) {
+  // getting all files of a path and of a specific filetype recursively
+  let list = [], stats,
+    files = fs.readdirSync(folder);
+
+  files.forEach(file => {
+    stats = fs.lstatSync(path.join(folder, file));
+    if(stats.isDirectory()) {
+      list = list.concat(getFilesRecursively(path.join(folder, file), filetype));
+    } else if (file.includes(filetype)) {
+      console.log('found:', path.join(folder, file)); 
+      list.push(path.join(folder, file)); 
+    }
+  });
+
+  return list;
+}
+
+// MAIN FUNCTIONS
+
+function addType(inputSchemaFile, options) {
+  // generates a new data type with all its files and <type> references
+  console.log(chalk.bold.blue('Running add-type'));
+  const fileUpdateList = getFileUpdateList(inputSchemaFile, 'add');
+  checkForFileChanges(fileUpdateList, options['force-update']);
+  createTypeFiles(fileUpdateList);
+  addPatternToFiles(fileUpdateList);
+  console.log(chalk.bold.blue('Finished successfully add-type'));
+  console.log('');
+}
+
+function removeType(inputSchemaFile, options) {
+  // removes the generated files and references only
+  console.log(chalk.bold.blue('Running remove-type'));
+  const fileUpdateList = getFileUpdateList(inputSchemaFile, 'remove');
+  checkForFileChanges(fileUpdateList, options['force-update']);
+  removePatternFromFiles(fileUpdateList);
+  removeTypeFiles(fileUpdateList);
+  console.log(chalk.bold.blue('Finished successfully remove-type'));
+  console.log('');
+}
+
+// CHECK AND REACT ON USER INPUTS
+console.log('');
+console.log(chalk.bold.blue('CREATE-GRAPHQL-SERVER'));
+console.log('');
 
 if (commands[0] === 'init') {
   const projectDir = commands[1];
   if (!projectDir) {
     usage();
   }
-
   // JWT key for encrypting tokens
   const key = process.env.JWT_KEY || Math.random().toString();
-
   // TODO - nice things like checking the directory doesn't exist
   cpr(SKEL_DIR, projectDir, { confirm: true, overwrite: true }, () => {
     const command = `find  * -type f  -exec sed -i '' -e 's/~name~/${projectDir}/' -e 's/~key~/${key}/' {} \\;`;
@@ -44,39 +455,32 @@ if (commands[0] === 'init') {
   if (!inputSchemaFile) {
     usage();
   }
-
-  const inputSchemaStr = fs.readFileSync(inputSchemaFile, 'utf8');
-  const {
-    typeName,
-    TypeName,
-    outputSchemaStr,
-    resolversStr,
-    modelStr,
-  } = generate(inputSchemaStr);
-
-  fs.writeFileSync(path.join('schema', `${TypeName}.graphql`), outputSchemaStr);
-  fs.writeFileSync(path.join('resolvers', `${TypeName}.js`), resolversStr);
-  fs.writeFileSync(path.join('model', `${TypeName}.js`), modelStr);
-
-  // We also need to add the relevant code to the end of each index.js file
-  // XXX: this is fairly hacky for now, we should at least check it's not there already
-  fs.appendFileSync(
-    path.join('schema', 'index.js'),
-    `\ntypeDefs.push(requireGraphQL('./${TypeName}.graphql'));\n`,
-  );
-
-  fs.appendFileSync(
-    path.join('resolvers', 'index.js'),
-    `\nimport ${typeName}Resolvers from './${TypeName}';\n` +
-      `merge(resolvers, ${typeName}Resolvers);\n`,
-  );
-
-  fs.appendFileSync(
-    path.join('model', 'index.js'),
-    `\nimport ${TypeName} from './${TypeName}';\n` +
-      `models.${TypeName} = ${TypeName};\n`,
-  );
-
+  if (fs.existsSync(inputSchemaFile) && fs.lstatSync(inputSchemaFile).isDirectory()) {
+    //directory name entered
+    const files = getFilesRecursively(inputSchemaFile, '.graphql');
+    files.forEach(file => {
+      addType(file, argv);
+    });
+  } else {
+    // single file entered
+    addType(inputSchemaFile, argv);
+  }
+  process.exit(0);
+} else if (commands[0] === 'remove-type') {
+  const inputSchemaFile = commands[1];
+  if (!inputSchemaFile) {
+    usage();
+  }
+  if (fs.existsSync(inputSchemaFile) && fs.lstatSync(inputSchemaFile).isDirectory()) {
+    // directory name entered
+    const files = getFilesRecursively(inputSchemaFile, '.graphql');
+    files.forEach(file => {
+      removeType(file, argv);
+    });
+  } else {
+    // single file or type
+    removeType(inputSchemaFile, argv);
+  }
   process.exit(0);
 } else {
   usage();

--- a/circle.yml
+++ b/circle.yml
@@ -15,3 +15,4 @@ test:
     - npm test
     - npm run output-app-generation-test
     - npm run end-to-end-test
+    - npm run test-add-update-remove

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "end-to-end-test": "./test/output-app-end-to-end/scripts/run-end-to-end-tests.sh",
     "preoutput-app-generation-test": "npm run build",
     "output-app-generation-test": "./test/output-app-generation-test.sh",
+    "pretest-add-update-remove": "npm run build",
+    "test-add-update-remove": "./test/test-add-update-remove.sh",
     "clean": "rm -rf dist/*",
     "build": "npm run clean && babel bin --out-dir dist/bin && babel generate -D --out-dir dist/generate && cp -r skel dist",
     "prepublish": "npm run build"
@@ -25,7 +27,7 @@
   "devDependencies": {
     "babel-cli": "6.16.0",
     "babel-core": "6.17.0",
-    "babel-eslint": "7.0.0",
+    "babel-eslint": "^7.0.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.17.0",
@@ -43,12 +45,15 @@
   },
   "dependencies": {
     "babylon": "^6.14.1",
+    "chalk": "^1.1.3",
     "cpr": "^2.0.0",
     "denodeify": "^1.2.1",
+    "escape-string-regexp": "^1.0.5",
     "graphql": "0.7.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.includes": "^4.3.0",
     "lodash.merge": "^4.6.0",
+    "md5": "^2.2.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "recast": "^0.11.18",

--- a/test/input/Order-after.graphql
+++ b/test/input/Order-after.graphql
@@ -1,0 +1,5 @@
+type Order {
+  customer: String!
+  value: String
+  notify: Boolean
+}

--- a/test/input/Order-before.graphql
+++ b/test/input/Order-before.graphql
@@ -1,0 +1,4 @@
+type Order {
+  customer: String!
+  value: String
+}

--- a/test/output-app-generation-test.sh
+++ b/test/output-app-generation-test.sh
@@ -7,10 +7,11 @@ popd > /dev/null
 CGS="$PACKAGE_DIR/dist/bin/create-graphql-server.js"
 INPUT_DIR="$PACKAGE_DIR/test/input"
 EXPECTED_OUTPUT_DIR="$PACKAGE_DIR/test/output-app"
-
+chmod +x $CGS
 set -e
 
 TMPDIR=`mktemp -d 2>/dev/null || mktemp -d -t 'cgs-test'`
+chmod -R 777 $TMPDIR
 function finish {
   rm -rf $TMPDIR
   echo
@@ -25,7 +26,7 @@ cd output-app
 $CGS add-type "$INPUT_DIR/Tweet.graphql"
 $CGS add-type "$INPUT_DIR/User.graphql"
 
-diff -rb . "$EXPECTED_OUTPUT_DIR" -x "db" -x "node_modules" -x "nohup.out"
+diff -rb . "$EXPECTED_OUTPUT_DIR" -x "db" -x "node_modules" -x "nohup.out" -x ".create-graphql-server.checksums"
 set +e
 
 trap - EXIT

--- a/test/test-add-update-remove.sh
+++ b/test/test-add-update-remove.sh
@@ -1,0 +1,245 @@
+#!/bin/bash 
+pushd "$(dirname $0)/.." > /dev/null 
+PACKAGE_DIR=`pwd` 
+popd > /dev/null
+
+CGS="$PACKAGE_DIR/dist/bin/create-graphql-server.js" 
+INPUT_DIR="$PACKAGE_DIR/test/input" 
+chmod +x $CGS
+ 
+set -e 
+MD5HASH=""
+TMPDIR1=`mktemp -d 2>/dev/null || mktemp -d -t 'cgs-test-start'` 
+TMPDIR2=`mktemp -d 2>/dev/null || mktemp -d -t 'cgs-test-end'` 
+TMPDIR3=`mktemp -d 2>/dev/null || mktemp -d -t 'cgs-test-directory-full'`
+
+chmod -R 777 $TMPDIR1
+chmod -R 777 $TMPDIR2 
+chmod -R 777 $TMPDIR3 
+
+function finish { 
+  rm -rf $TMPDIR1
+  rm -rf $TMPDIR2 
+  rm -rf $TMPDIR3 
+  echo 
+  echo 
+  echo "Test failed" 
+} 
+trap finish EXIT
+
+function exists {
+  if [ -f $1 ] ; then
+    return 0
+  else
+    echo "Error: File is missing: " $1
+    return 1
+  fi
+}
+
+function hasRef {
+  if [ -f $1 ] ; then
+    if [ `grep -o $2 $1 | wc -l` -eq $3 ] ; then
+      return 0
+    else
+      echo "Error: File" $1 "contains" `grep -o $2 $1 | wc -l` "times the string '"$2"'. Expected are" $3 "times."
+      return 1
+    fi
+  else
+    echo "Error: File is missing: " $1
+    return 1
+  fi
+}
+
+function getMD5 {
+  # Detect Operating system
+  OS=$(uname)
+  MD5HASH=""
+  case "$OS" in
+    "Darwin")
+    { 
+      MD5HASH=$(md5 -q $1)
+    } ;;
+    "Linux")
+    {
+      MD5HASH=($(md5sum $1))
+    } ;;
+    *)
+    {
+      echo "Test failed. Unsopported OS"
+      exit
+    } ;;
+  esac
+  echo "$MD5HASH"
+}
+
+# Prepare two directories for later comparisons with each other
+cd $TMPDIR3 
+JWT_KEY='test-key' $CGS init output-app-start
+
+cd $TMPDIR2 
+JWT_KEY='test-key' $CGS init output-app-start
+
+cd $TMPDIR1 
+JWT_KEY='test-key' $CGS init output-app-start
+
+cd output-app-start
+$CGS add-type "$INPUT_DIR/Order-after.graphql" 
+$CGS add-type "$INPUT_DIR/Order-before.graphql" 
+$CGS add-type "$INPUT_DIR/Tweet.graphql" 
+$CGS add-type "$INPUT_DIR/User.graphql" 
+# TEST1: Testing of 4 add-types 
+# it (should be pattern User, Tweet, Order in model/index.js)
+# it (should be pattern User, Tweet, Order  in resolvers/index.js)
+# it (should be pattern User, Tweet, Order  in schema/index.js)
+# it (should be a model/User.js, resolver/User.js, schema/User.graphql)
+# it (should be a model/Tweet.js, resolver/Tweet.js, schema/Tweet.graphql)
+# it (should be a model/Order.js, resolver/Order.js, schema/Order.graphql)
+# testing files for existence:
+
+if  exists "./model/User.js" &&
+    exists "./model/Tweet.js" &&
+    exists "./model/Order.js" &&
+    exists "./resolvers/User.js" &&
+    exists "./resolvers/Tweet.js" &&
+    exists "./resolvers/Order.js" &&
+    exists "./schema/User.graphql" &&
+    exists "./schema/Tweet.graphql" &&
+    exists "./schema/Order.graphql" &&
+    hasRef "./model/index.js" "User" 4 &&
+    hasRef "./model/index.js" "Tweet" 4 &&
+    hasRef "./model/index.js" "Order" 4 &&
+    hasRef "./resolvers/index.js" "userResolvers" 2 &&
+    hasRef "./resolvers/index.js" "tweetResolvers" 2 &&
+    hasRef "./resolvers/index.js" "orderResolvers" 2 &&
+    hasRef "./schema/index.js" "./User.graphql" 1 &&
+    hasRef "./schema/index.js" "./Tweet.graphql" 1 &&
+    hasRef "./schema/index.js" "./Order.graphql" 1 ; then
+  echo "Test Passed Test1: 4 add-types"
+else 
+  echo "Test Failed Test1: 4 add-types"
+fi
+
+$CGS add-type "$INPUT_DIR/Order-before.graphql" 
+# TEST2: Testing of an update
+# it (should have a schema/Order.graphql, model/Order.js, resolvers/Order.js file)
+# it (should have a pattern in schema/index.js, resolvers/index.js, model/index.js)
+# testing files for existence: 
+if  exists "./model/User.js" &&
+    exists "./model/Tweet.js" &&
+    exists "./model/Order.js" &&
+    exists "./resolvers/User.js" &&
+    exists "./resolvers/Tweet.js" &&
+    exists "./resolvers/Order.js" &&
+    exists "./schema/User.graphql" &&
+    exists "./schema/Tweet.graphql" &&
+    exists "./schema/Order.graphql" &&
+    hasRef "./model/index.js" "User" 4 &&
+    hasRef "./model/index.js" "Tweet" 4 &&
+    hasRef "./model/index.js" "Order" 4 &&
+    hasRef "./resolvers/index.js" "userResolvers" 2 &&
+    hasRef "./resolvers/index.js" "tweetResolvers" 2 &&
+    hasRef "./resolvers/index.js" "orderResolvers" 2 &&
+    hasRef "./schema/index.js" "./User.graphql" 1 &&
+    hasRef "./schema/index.js" "./Tweet.graphql" 1 &&
+    hasRef "./schema/index.js" "./Order.graphql" 1 ; then
+  echo "Test Passed Test2: update with add-type without file change"
+else 
+  echo "Test Failed Test2: update with add-type without file change"
+fi
+
+echo "# Comment " >> "./model/Order.js"
+File1=$(getMD5 "./model/Order.js")
+$CGS add-type "$INPUT_DIR/Order-after.graphql" 
+File2=$(getMD5 "./model/Order.js")
+# TEST3: Testing of update with changed model/Order.js file
+# it (should still have the same MD5, meaning file shouldn't have changed)
+echo "Calculated Hashes are: $File1 $File2"
+if [ "$File1" == "$File2" ]; then
+  echo "Test Passed Test3: update with add-type and file change"
+else
+  echo "Test Failed Test3: update with add-type and file change"
+fi
+ 
+echo "\n" >> ./model/Order.js
+File1=$(getMD5 "./model/Order.js")
+$CGS add-type "$INPUT_DIR/Order-after.graphql" --force-update
+File2=$(getMD5 "./model/Order.js")
+# TEST4: Testing of update with add-type with changed model/Order.js file with force-update option
+# it (should have a different MD5, meaning force-update has altered the file)
+echo "Calculated Hashes are: $File1 $File2"
+if [ "$File1" != "$File2" ]; then
+  echo "Test Passed Test4: update with add-type and file change in --force-update mode"
+else
+  echo "Test Failed Test4: update with add-type and file change in --force-update mode"
+fi
+
+$CGS remove-type "$INPUT_DIR/Order-after.graphql" 
+$CGS remove-type "TWEET" 
+$CGS remove-type "user" 
+# TEST5: Testing 3 remove-types
+# it (should be a equal app-test-start and app-test-end directory)
+diff -rb "$TMPDIR1" "$TMPDIR2" -x "db" -x "node_modules" -x "nohup.out" -x ".create-graphql-server.checksums"
+if [ $? -eq 0 ] ; then 
+  echo "Test Passed Test5: 3x remove-type should be equal to the initial directory"
+else  
+  echo "Test Failed Test5: 3x remove-type should be equal to the initial directory"
+fi
+
+# Preparing TEST6 do add-types in alphabetical order to get the right order of references
+echo "Preparing Test 6: add-type in the right order for testing full path test with correct reference order"
+$CGS add-type "$INPUT_DIR/Order-after.graphql" 
+$CGS add-type "$INPUT_DIR/Order-before.graphql" 
+$CGS add-type "$INPUT_DIR/Tweet.graphql" 
+$CGS add-type "$INPUT_DIR/User.graphql" 
+cd $TMPDIR3
+cd output-app-start
+echo "Do add-type path (all graphql files of the test/input directory in one command)"
+$CGS add-type "$INPUT_DIR"
+diff -rb "$TMPDIR1" "$TMPDIR3" -x "db" -x "node_modules" -x "nohup.out" -x ".create-graphql-server.checksums"
+if [ $? -eq 0 ] ; then 
+  echo "Test Passed Test6: add-type path equals the same like multiple single add-type"
+else  
+  echo "Test Failed Test6: add-type path equals the same like multiple single add-type"
+fi
+
+# TEST7: Testing correct files in TMPDIR3
+# it (should have a schema/Order.graphql, model/Order.js, resolvers/Order.js file)
+# it (should have a pattern in schema/index.js, resolvers/index.js, model/index.js)
+# testing files for existence: 
+if  exists "./model/User.js" &&
+    exists "./model/Tweet.js" &&
+    exists "./model/Order.js" &&
+    exists "./resolvers/User.js" &&
+    exists "./resolvers/Tweet.js" &&
+    exists "./resolvers/Order.js" &&
+    exists "./schema/User.graphql" &&
+    exists "./schema/Tweet.graphql" &&
+    exists "./schema/Order.graphql" &&
+    hasRef "./model/index.js" "User" 4 &&
+    hasRef "./model/index.js" "Tweet" 4 &&
+    hasRef "./model/index.js" "Order" 4 &&
+    hasRef "./resolvers/index.js" "userResolvers" 2 &&
+    hasRef "./resolvers/index.js" "tweetResolvers" 2 &&
+    hasRef "./resolvers/index.js" "orderResolvers" 2 &&
+    hasRef "./schema/index.js" "./User.graphql" 1 &&
+    hasRef "./schema/index.js" "./Tweet.graphql" 1 &&
+    hasRef "./schema/index.js" "./Order.graphql" 1 ; then
+  echo "Test Passed Test7: add-type path has also correct files and references"
+else 
+  echo "Test Failed Test7: add-type path has also correct files and references"
+fi
+
+echo "Test8 do remove-type path"
+$CGS remove-type "$INPUT_DIR"
+diff -rb "$TMPDIR2" "$TMPDIR3" -x "db" -x "node_modules" -x "nohup.out" -x ".create-graphql-server.checksums"
+if [ $? -eq 0 ] ; then 
+  echo "Test Passed Test8: remove-type path should be also equal to the initial directory"
+else  
+  echo "Test Failed Test8: remove-type path should be also equal to the initial directory"
+fi
+
+set +e 
+trap - EXIT 
+echo " "
+echo "ALL TESTS PASSED"
+echo " "

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,6 +911,10 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 chokidar@^1.0.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
@@ -1000,6 +1004,10 @@ cpr:
     minimist "^1.2.0"
     mkdirp "~0.5.1"
     rimraf "^2.5.4"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -1720,7 +1728,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2:
+is-buffer@^1.0.2, is-buffer@~1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
@@ -2051,6 +2059,14 @@ loud-rejection@^1.0.0:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 meow@^3.5.0:
   version "3.7.0"


### PR DESCRIPTION
Enhanced create-graphql-server with an "update-type", "remove-type" procedure. 

If a file was changed by a user, which will be overwritten by any "*-type" command, it warns and stops. If the user decides, that it is ok to overwrite, he can restart the previous command with a "force-update" option to overrule the check. 

The file change recognition works with a simple md5 hash calculation, which is stored in a file 'GraphQL.checksums'. In the beginning it is not there, it will be created by the first "add-type" run. 

Added some colors to the CLI user interface to recognize errors more easily. 

Added a test with a new "test/test-add-update-remove.sh" script. 

This test creates two temporary directories and does a CGS init into both of them. In the first directory it does several changes with 3x add-type, then an update-type, an update-type with file change, an update-type with file-change and "force-update" option, and finally it does 3x remove-type. Then the first and the second directory are compared with each other, as they have to be equally again.

The 5 tests check for generated file existences and if the index files contains the type string which has the type file loaded.

Please have a look, if it fits to your project principles and quality expectations.