### PR TITLE
subscribe now returns the correct asyncIterator from pubsub

### DIFF
--- a/generate/resolvers/templates/base.js.template
+++ b/generate/resolvers/templates/base.js.template
@@ -1,3 +1,5 @@
+import { pubsub } from '.';
+
 const resolvers = {
   TypeName: {
     id(typeName) {
@@ -29,9 +31,18 @@ const resolvers = {
     },
   },
   Subscription: {
-    typeNameCreated: typeName => typeName,
-    typeNameUpdated: typeName => typeName,
-    typeNameRemoved: id => id,
+    typeNameCreated: {
+        resolve: typeName => typeName,
+        subscribe: () => pubsub.asyncIterator('typeNameInserted')
+    },
+    typeNameUpdated: {
+        resolve: typeName => typeName,
+        subscribe: () => pubsub.asyncIterator('typeNameUpdated')
+    },
+    typeNameRemoved: {
+        resolve: id => id,
+        subscribe: () => pubsub.asyncIterator('typeNameRemoved')
+    },
   },
 };
 

--- a/skel/resolvers/index.js
+++ b/skel/resolvers/index.js
@@ -2,24 +2,26 @@ import { ObjectId } from 'mongodb';
 import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 import { merge } from 'lodash';
+import { pubsub } from '../server/subscriptions';
 
 const resolvers = {};
 
 resolvers.ObjID = new GraphQLScalarType({
-  name: 'ObjID',
-  description: 'Id representation, based on Mongo Object Ids',
-  parseValue(value) {
-    return ObjectId(value);
-  },
-  serialize(value) {
-    return value.toString();
-  },
-  parseLiteral(ast) {
-    if (ast.kind === Kind.STRING) {
-      return ObjectId(ast.value);
-    }
-    return null;
-  },
+	name: 'ObjID',
+	description: 'Id representation, based on Mongo Object Ids',
+	parseValue(value) {
+		return ObjectId(value);
+	},
+	serialize(value) {
+		return value.toString();
+	},
+	parseLiteral(ast) {
+		if (ast.kind === Kind.STRING) {
+			return ObjectId(ast.value);
+		}
+		return null;
+	}
 });
 
+export { pubsub };
 export default resolvers;

--- a/skel/schema/index.js
+++ b/skel/schema/index.js
@@ -1,11 +1,20 @@
 import fs from 'fs';
 
+/* requireGraphQL for Webpack
+
+const req = require.context('./', true, /\.graphql$/);
 function requireGraphQL(name) {
-  const filename = require.resolve(name);
-  return fs.readFileSync(filename, 'utf8');
+	return req(name);
+}
+*/
+
+function requireGraphQL(name) {
+	const filename = require.resolve(name);
+	return fs.readFileSync(filename, 'utf8');
 }
 
-const typeDefs = [`
+const typeDefs = [
+	`
   scalar ObjID
   type Query {
     # A placeholder, please ignore
@@ -19,6 +28,7 @@ const typeDefs = [`
     # A placeholder, please ignore
     __placeholder: Int
   }
-`];
+`
+];
 
 export default typeDefs;


### PR DESCRIPTION
I use the CLI to generate code inside an another project, with my own webServer ( Koa2 )
It generates the resolvers I need and increases my productivity a LOT

I modified the script a bit in order to use it in my project

My edits :
Modified template to return pubsub AsyncIterator on subscribe
Added a commented function to resolve schema files in webpack bundled projects

Signed-off-by: Aetherall <elies.lou@atmost.fr>